### PR TITLE
Display mode bar on hover and add download buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ where `grist-plugin-api.js` is loaded.
   },
   dataSourceOptions: [
     {value: 'gristsrc:11', label: 'Column A'},
-    {value: 'gristsrc:12', label: 'Column B''},
-    {value: 'gristsrc:13', label: 'Column C''},
+    {value: 'gristsrc:12', label: 'Column B'},
+    {value: 'gristsrc:13', label: 'Column C'},
     ...
   ],
 }

--- a/src/index.js
+++ b/src/index.js
@@ -258,7 +258,20 @@ class App extends Component {
         hideControls={this.state.hideControls}
         data={this.state.data}
         layout={this.state.layout}
-        config={{ displayModeBar: false }}
+        config={{
+          displayModeBar: true,
+          displaylogo: false,
+          modeBarButtonsToRemove: [
+            "zoom2d",
+            "zoomIn2d",
+            "zoomOut2d",
+            "pan2d",
+            "select2d",
+            "lasso2d",
+            "autoScale2d",
+            "resetScale2d",
+          ],
+        }}
         frames={this.state.frames}
         dataSources={this.state.dataSources}
         dataSourceOptions={this.state.dataSourceOptions}

--- a/src/index.js
+++ b/src/index.js
@@ -261,16 +261,6 @@ class App extends Component {
         config={{
           displayModeBar: true,
           displaylogo: false,
-          modeBarButtonsToRemove: [
-            "zoom2d",
-            "zoomIn2d",
-            "zoomOut2d",
-            "pan2d",
-            "select2d",
-            "lasso2d",
-            "autoScale2d",
-            "resetScale2d",
-          ],
         }}
         frames={this.state.frames}
         dataSources={this.state.dataSources}

--- a/src/index.js
+++ b/src/index.js
@@ -274,7 +274,7 @@ class App extends Component {
             },
             {
               name: "Download plot as an svg",
-              icon: plotly.Icons.camera,
+              icon: plotly.Icons.disk,
               click: function (graphDiv) {
                 plotly.downloadImage(graphDiv, {
                   format: "svg",

--- a/src/index.js
+++ b/src/index.js
@@ -261,6 +261,29 @@ class App extends Component {
         config={{
           displayModeBar: true,
           displaylogo: false,
+          modeBarButtonsToAdd: [
+            {
+              name: "Download plot as a png",
+              icon: plotly.Icons.camera,
+              click: function (graphDiv) {
+                plotly.downloadImage(graphDiv, {
+                  format: "png",
+                  filename: "newplot",
+                });
+              },
+            },
+            {
+              name: "Download plot as an svg",
+              icon: plotly.Icons.camera,
+              click: function (graphDiv) {
+                plotly.downloadImage(graphDiv, {
+                  format: "svg",
+                  filename: "newplot",
+                });
+              },
+            },
+          ],
+          modeBarButtonsToRemove: ["toImage"],
         }}
         frames={this.state.frames}
         dataSources={this.state.dataSources}

--- a/src/index.js
+++ b/src/index.js
@@ -259,7 +259,7 @@ class App extends Component {
         data={this.state.data}
         layout={this.state.layout}
         config={{
-          displayModeBar: true,
+          displayModeBar: "hover",
           displaylogo: false,
           modeBarButtonsToAdd: [
             {


### PR DESCRIPTION
The mode bar is now shown on hover with the default buttons, and two additional buttons: one to download the plot as a PNG, and another to download it as an SVG. See attached screenshots.

Addresses #8.

<img width="612" alt="Screenshot 2025-06-11 at 10 15 56 PM" src="https://github.com/user-attachments/assets/ab46a063-b58c-4df5-9e97-946ffa37a13b" />

<img width="622" alt="Screenshot 2025-06-11 at 10 16 05 PM" src="https://github.com/user-attachments/assets/13855e4f-f9e0-4c3e-b97b-714964cbce4d" />
